### PR TITLE
Add type hints (PEP 484)

### DIFF
--- a/is_even/is_even.py
+++ b/is_even/is_even.py
@@ -1,11 +1,12 @@
 import requests
 from functools import lru_cache
 from retry import retry
+from typing import Union
 
 
 @lru_cache(maxsize=None)
 @retry(ConnectionError, tries=3, delay=2)
-def is_even(number):
+def is_even(number: Union[str, int]) -> bool:
     n = int(number)
     r = requests.get(f"https://api.isevenapi.xyz/api/iseven/{n}/")
 
@@ -15,7 +16,7 @@ def is_even(number):
         raise Exception(r.json()["error"])
 
 
-def is_odd(number):
+def is_odd(number: Union[str, int]) -> bool:
     return not is_even(number)
 
 


### PR DESCRIPTION
This change adds type hints to the library, to allow better compatibility with static type checkers such as PyRight, MyPy, etc. Type hints were added in Python 3.5, but PyIsEven uses f-strings which were added in Python 3.6, so this is not a breaking change.

For more information about type hints: https://www.python.org/dev/peps/pep-0484/